### PR TITLE
added callback_accept(image)

### DIFF
--- a/src/lazyload.js
+++ b/src/lazyload.js
@@ -37,6 +37,7 @@
                 callback_error: null,
                 callback_set: null,
                 callback_processed: null,
+                callback_accept: null,
                 placeholder: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
             };
             _supportsAddEventListener = !!window.addEventListener;
@@ -339,11 +340,13 @@
                 continue;
             }
             if (_isInsideViewport(element, settings.container, settings.threshold)) {
-                /* Forking behaviour depending on show_while_loading (true value is ideal for progressive jpeg). */
-                if (settings.show_while_loading) {
-                    this._showOnAppear(element);
-                } else {
-                    this._showOnLoad(element);
+                if( !settings.callback_processed || settings.callback_accept(element) == true ) {
+                    /* Forking behaviour depending on show_while_loading (true value is ideal for progressive jpeg). */
+                    if (settings.show_while_loading) {
+                        this._showOnAppear(element);
+                    } else {
+                        this._showOnLoad(element);
+                    }
                 }
                 /* Marking the element as processed. */
                 processedIndexes.push(i);


### PR DESCRIPTION
Lets you drop images if they do not require lazy loading, although they got targeted in elements_selector option.
I need a way in my application to exclude some images in specific containers, but there is no possible CSS selector to do so directly.
